### PR TITLE
add approve dependency for license-check ci

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -38,8 +38,17 @@ jobs:
 
       - name: Add dependency approvals
         run: |
-          license_finder approvals add "github.com/go-redis/redis/v8 github.com/hashicorp/terraform-plugin-framework github.com/hashicorp/terraform-plugin-framework-validators"
-      
+          license_finder approvals add 
+          github.com/hashicorp/terraform-plugin-framework 
+          github.com/hashicorp/terraform-plugin-framework-validators 
+          github.com/hashicorp/go-plugin 
+          github.com/hashicorp/go-uuid 
+          github.com/hashicorp/terraform-plugin-go 
+          github.com/hashicorp/terraform-plugin-log 
+          github.com/hashicorp/terraform-registry-address 
+          github.com/hashicorp/terraform-svchost 
+          github.com/hashicorp/yamux 
+
       - name: Report dependency licenses
         run: license_finder report
 

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -38,16 +38,7 @@ jobs:
 
       - name: Add dependency approvals
         run: |
-          license_finder approvals add 
-          github.com/hashicorp/terraform-plugin-framework 
-          github.com/hashicorp/terraform-plugin-framework-validators 
-          github.com/hashicorp/go-plugin 
-          github.com/hashicorp/go-uuid 
-          github.com/hashicorp/terraform-plugin-go 
-          github.com/hashicorp/terraform-plugin-log 
-          github.com/hashicorp/terraform-registry-address 
-          github.com/hashicorp/terraform-svchost 
-          github.com/hashicorp/yamux 
+          license_finder approvals add github.com/hashicorp/terraform-plugin-framework github.com/hashicorp/terraform-plugin-framework-validators github.com/hashicorp/go-plugin github.com/hashicorp/go-uuid github.com/hashicorp/terraform-plugin-go github.com/hashicorp/terraform-plugin-log github.com/hashicorp/terraform-registry-address github.com/hashicorp/terraform-svchost github.com/hashicorp/yamux 
 
       - name: Report dependency licenses
         run: license_finder report

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -38,7 +38,15 @@ jobs:
 
       - name: Add dependency approvals
         run: |
-          license_finder approvals add github.com/hashicorp/terraform-plugin-framework github.com/hashicorp/terraform-plugin-framework-validators github.com/hashicorp/go-plugin github.com/hashicorp/go-uuid github.com/hashicorp/terraform-plugin-go github.com/hashicorp/terraform-plugin-log github.com/hashicorp/terraform-registry-address github.com/hashicorp/terraform-svchost github.com/hashicorp/yamux 
+          license_finder approvals add \
+          github.com/hashicorp/terraform-plugin-framework \
+          github.com/hashicorp/terraform-plugin-framework-validators \
+          github.com/hashicorp/go-plugin github.com/hashicorp/go-uuid \
+          github.com/hashicorp/terraform-plugin-go \
+          github.com/hashicorp/terraform-plugin-log \
+          github.com/hashicorp/terraform-registry-address \
+          github.com/hashicorp/terraform-svchost \
+          github.com/hashicorp/yamux 
 
       - name: Report dependency licenses
         run: license_finder report


### PR DESCRIPTION
### 直接依賴項

terraform-plugin-framework:
用途: terraform plugin 開發框架
[repo](https://github.com/hashicorp/terraform-plugin-framework?tab=readme-ov-file), [license](https://github.com/hashicorp/terraform-plugin-framework/blob/main/LICENSE)

terraform-plugin-framework-validators:
用途: 用來驗證terraform 傳入參數
[repo](https://github.com/hashicorp/terraform-plugin-framework-validators), [license](https://github.com/hashicorp/terraform-plugin-framework-validators/blob/main/LICENSE)